### PR TITLE
Eytzinger Ordering

### DIFF
--- a/compare_searches.c
+++ b/compare_searches.c
@@ -1,0 +1,105 @@
+// much of this was cribbed from 
+// https://algorithmica.org/en/eytzinger
+// https://stackoverflow.com/questions/3893937/sorting-an-array-in-c
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <math.h>
+#include <stdalign.h>
+#include <time.h>
+
+int eytzinger_helper(int *input, int *output, int n, int i, int k) {
+    if (k <= n) {
+        i = eytzinger_helper(input, output, n, i, 2 * k);
+        output[k] = input[i++];
+        i = eytzinger_helper(input, output, n, i, 2 * k + 1);
+    }
+    return i;
+}
+
+void eytzinger(int *input, int *output, int n) {
+	eytzinger_helper(input, output, n, 0, 1);
+}
+
+int compare( const void* a, const void* b)
+{
+     int int_a = * ( (int*) a );
+     int int_b = * ( (int*) b );
+
+     if ( int_a == int_b ) return 0;
+     else if ( int_a < int_b ) return -1;
+     else return 1;
+}
+
+
+int eytzinger_search(int* array, int n, int x) {
+	int block_size = 16;
+    int k = 1;
+    while (k <= n) {
+        __builtin_prefetch(array + k * block_size);
+        k = 2 * k + (array[k] < x);
+    }
+    k >>= __builtin_ffs(~k);
+    return k;
+}
+
+int binary_search(int* array, int n, int x) {
+    int l = 0, r = n - 1;
+    while (l < r) {
+        int t = (l + r) / 2;
+        if (array[t] >= x)
+            r = t;
+        else
+            l = t + 1;
+    }
+    return array[l];
+}
+
+int main() {
+	const int n = 1 << 20; // ~1e6
+	alignas(64) int *input = (int*)calloc(n, sizeof(int));
+	for (int i = 0; i < n; i++) {
+		input[i] = random();
+	}
+
+	alignas(64) int *output = (int*)calloc(n+1, sizeof(int));
+	qsort(input, n, sizeof(int), compare );
+	eytzinger(input, output, n);
+
+	clock_t start, end;
+	double time_taken;
+	int x;
+
+	start = clock();
+	for (int target = 0; target < 100000; target++) {
+		x = eytzinger_search(output, n, input[target]);
+	}
+	end = clock();
+	time_taken = (double)(end - start) / (double)(CLOCKS_PER_SEC);
+
+	printf("eytzinger: %.2f msec, x=%d\n", time_taken * 1000, x);
+
+	start = clock();
+	for (int target = 0; target < 100000; target++) {
+		x = binary_search(input, n, output[target]);
+	}
+	end = clock();
+	time_taken = (double)(end - start) / (double)(CLOCKS_PER_SEC);
+
+	printf("binary: %.2f msec, x=%d\n", time_taken * 1000, x);
+
+	start = clock();
+	for (int target = 0; target < 100000; target++) {
+		x = eytzinger_search(output, n, input[target]);
+	}
+	end = clock();
+	time_taken = (double)(end - start) / (double)(CLOCKS_PER_SEC);
+
+	printf("eytzinger: %.2f msec, x=%d\n", time_taken * 1000, x);
+
+	free(input);
+	free(output);
+
+	return 0;
+}

--- a/mapbuffer/mapbuffer.py
+++ b/mapbuffer/mapbuffer.py
@@ -258,6 +258,7 @@ class MapBuffer:
 
     return True
 
+# Function c/o https://algorithmica.org/en/eytzinger
 def eytzinger(inpt, output, i = 0, k = 1):
   if k <= len(inpt):
     i = eytzinger(inpt, output, i, 2 * k)
@@ -266,6 +267,7 @@ def eytzinger(inpt, output, i = 0, k = 1):
     i = eytzinger(inpt, output,i, 2 * k + 1)
   return i
 
+# function c/o https://stackoverflow.com/questions/5520655/return-index-of-least-significant-bit-in-python
 def ffs(x):
   """Returns the index, counting from 1, of the
   least significant set bit in `x`.

--- a/mapbuffer/mapbuffer.py
+++ b/mapbuffer/mapbuffer.py
@@ -152,21 +152,19 @@ class MapBuffer:
 
     label = np.uint64(label)
 
-    first, last = 0, N
-    count = N
-    while count > 0:
-      i = first
-      step = count // 2
-      i += step
-      if index[i,0] < label:
-        i += 1
-        first = i
-        count -= step + 1
-      else:
-        count = step
+    # Cache aware Binary search using eytzinger ordering
+    # not necessarily faster in Python, but
+    # leaves the door open for C++ implementations.
+    # Since this is a format, if we don't support it from
+    # the start, it'll never happen without headaches.
+    k = 1
+    while (k <= N):
+      k = 2 * k + (index[k-1,0] < label)
+    k >>= ffs(~k)
+    k -= 1
 
-    if first < N and label == index[first,0]:
-      return self.getindex(first)
+    if k < N and label == index[k,0]:
+      return self.getindex(k)
     
     raise KeyError("{} was not found.".format(label))
 
@@ -174,6 +172,11 @@ class MapBuffer:
     """Structure [ index length, sorted index, data ]"""
     labels = np.array([ int(lbl) for lbl in data.keys() ], dtype=self.dtype)
     labels.sort()
+
+    out = np.zeros((len(labels),), dtype=np.uint64)
+    eytzinger(labels, out)
+    labels = out
+
     N = len(labels)
     N_region = N.to_bytes(4, byteorder="little", signed=False)
 
@@ -246,12 +249,26 @@ class MapBuffer:
       if length != mapbuf.datasize():
         raise ValidationError(f"Data length doesn't match offsets. Predicted: {length} Data Size: {mapbuf.datasize()}")
 
-      labels = index[:,0].astype(np.int64)
-      labeldiff = labels[1:] - labels[0:-1]
-      if np.any(labeldiff < 1):
-        raise ValidationError("Labels aren't sorted.")
+      # labels = index[:,0].astype(np.int64)
+      # labeldiff = labels[1:] - labels[0:-1]
+      # if np.any(labeldiff < 1):
+      #   raise ValidationError("Labels aren't sorted.")
     elif len(buf) != HEADER_LENGTH:
       raise ValidationError("Format is longer than header for zero data.")
 
     return True
+
+def eytzinger(inpt, output, i = 0, k = 1):
+  if k <= len(inpt):
+    i = eytzinger(inpt, output, i, 2 * k)
+    output[k - 1] = inpt[i]
+    i += 1
+    i = eytzinger(inpt, output,i, 2 * k + 1)
+  return i
+
+def ffs(x):
+  """Returns the index, counting from 1, of the
+  least significant set bit in `x`.
+  """
+  return int(x & -x).bit_length()
 

--- a/mapbuffer/mapbuffer.py
+++ b/mapbuffer/mapbuffer.py
@@ -153,7 +153,7 @@ class MapBuffer:
     label = np.uint64(label)
 
     # Cache aware Binary search using eytzinger ordering
-    # not necessarily faster in Python, but
+    # not necessarily faster in Python (1.5x slower?), but
     # leaves the door open for C++ implementations.
     # Since this is a format, if we don't support it from
     # the start, it'll never happen without headaches.

--- a/mapbuffer/mapbuffer.py
+++ b/mapbuffer/mapbuffer.py
@@ -146,7 +146,7 @@ class MapBuffer:
 
   def __getitem__(self, label):
     index = self.index()
-    N = len(index)
+    N = np.uint64(len(index))
     if N == 0:
       return None
 
@@ -157,14 +157,15 @@ class MapBuffer:
     # leaves the door open for C++ implementations.
     # Since this is a format, if we don't support it from
     # the start, it'll never happen without headaches.
-    k = 1
-    while (k <= N):
-      k = 2 * k + (index[k-1,0] < label)
-    k >>= ffs(~k)
-    k -= 1
+    k = np.uint64(1)
+    one = np.uint64(1)
+    while k <= N:
+      k = (k << one) + (index[(k-one),0] < label)
+    k >>= np.uint64(ffs(~k))
+    k -= one
 
     if k < N and label == index[k,0]:
-      return self.getindex(k)
+      return self.getindex(int(k))
     
     raise KeyError("{} was not found.".format(label))
 


### PR DESCRIPTION
If we use Eytzinger order for our labels, we can use a cache-aware binary search that is faster. This is a bit slower in Python for some reason (1.5x), but it makes the possibilities for the future richer.