### PR TITLE
fix: PROT_READ is a UNIX parameter

### DIFF
--- a/mapbuffer/mapbuffer.py
+++ b/mapbuffer/mapbuffer.py
@@ -49,7 +49,7 @@ class MapBuffer:
     if isinstance(data, dict):
       self.buffer = self.dict2buf(data, compress)
     elif isinstance(data, io.IOBase):
-      self.buffer = mmap.mmap(data.fileno(), 0, prot=mmap.PROT_READ)
+      self.buffer = mmap.mmap(data.fileno(), 0, access=mmap.ACCESS_READ)
     elif isinstance(data, (bytes, mmap.mmap)):
       self.buffer = data
     elif hasattr(data, "__getitem__"):


### PR DESCRIPTION
access=ACCESS_READ should work for all vs
prot=PROT_READ which is unix only.

https://docs.python.org/3/library/mmap.html