### PR TITLE
Format Version 1: Adds crc32c checks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ The byte string format consists of a 16 byte header, an index, and a series of (
 HEADER|INDEX|DATA_REGION
 ```
 
+| Format Version | description                            |
+|----------------|----------------------------------------|
+| 0              | Initial Release                        |
+| 1              | Adds crc32c check values to each item. |
+
 ### Header 
 
 ```
@@ -93,7 +98,7 @@ The index can be consulted by conducting an Eytzinger binary search over the lab
 
 ### Data Region
 
-The data objects are serialized to bytes and compressed individually if the header indicates they should be. They are then concatenated in the same order the index specifies.
+The data objects are serialized to bytes and compressed individually if the header indicates they should be. They are then concatenated in the same order the index specifies. The last four bytes are a crc32c check value that was added in format version 1.
 
 ## Versus Flexbuffers
 

--- a/mapbuffer/mapbuffer.py
+++ b/mapbuffer/mapbuffer.py
@@ -5,11 +5,12 @@ from .exceptions import ValidationError
 from .lib import nvl
 from . import compression
 
+import crc32c
 import numpy as np
 
 import mapbufferaccel
 
-FORMAT_VERSION = 0
+FORMAT_VERSION = 1
 MAGIC_NUMBERS = b"mapbufr"
 HEADER_LENGTH = 16
 
@@ -133,6 +134,13 @@ class MapBuffer:
     else:
       value = self.buffer[offset:]
 
+    if self.format_version == 1:
+      stored_check_value = int.from_bytes(value[-4:], byteorder='little')
+      value = value[:-4]
+      retrieved_check_value = crc32c.crc32c(value)
+      if retrieved_check_value != stored_check_value:
+        raise ValidationError(f"Label {i} failed its crc32c check. Stored: {stored_check_value} Computed: {retrieved_check_value}")
+
     encoding = self.compress
     if encoding:
       value = compression.decompress(value, encoding, str(index[i,0]))
@@ -213,6 +221,8 @@ class MapBuffer:
       label: compression.compress(tobytesfn(val), method=compress) 
       for label, val in data.items()
     }
+    for label in bytes_data:
+      bytes_data[label] += crc32c.crc32c(bytes_data[label]).to_bytes(4, byteorder='little')
 
     data_region = b"".join(
       ( bytes_data[label] for label in labels )
@@ -244,7 +254,7 @@ class MapBuffer:
     if magic != MAGIC_NUMBERS:
       raise ValidationError(f"Magic number mismatch. Expected: {MAGIC_NUMBERS} Got: {magic}")
 
-    if mapbuf.format_version not in (0,):
+    if mapbuf.format_version not in (0,1):
       raise ValidationError(f"Unsupported format version. Got: {mapbuf.format_version}")
 
     if mapbuf.compress not in compression.COMPRESSION_TYPES:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 brotli
+crc32c
 deflate>=0.2.0
 numpy
 tqdm


### PR DESCRIPTION
A uint32le crc32c check value is appended to each stored item and validated upon retrieval.

Latest mapbuffer implementation will be backwards compatible with format version 0.